### PR TITLE
Raise ValueError when style/content is not found

### DIFF
--- a/christmais/styler.py
+++ b/christmais/styler.py
@@ -84,6 +84,11 @@ class Styler:
         """
         content_img_list = glob.glob('./**/{}'.format(content_path), recursive=True)
         style_img_list = glob.glob('./**/{}'.format(style_path), recursive=True)
+        if len(style_img_list) == 0 or len(content_img_list) == 0:
+            msg = 'Content or style path not found! Make sure it\'s in repo root!'
+            self.logger.error(msg)
+            raise ValueError(msg)
+
         if len(style_img_list) > max_styles:
             self.logger.warn(
                 'Image list is greater than max_styles_to_evaluate'


### PR DESCRIPTION
Before it's just silent and it doesn't give any warnings/errors
whatsoever. Now it gives us a ValueError and the process stops.

Sample run with missing style image:

![error_when_missing](https://user-images.githubusercontent.com/12949683/49985859-7d811400-ffa8-11e8-8aab-4612dc90b68f.png)
