### PR TITLE
Fix edge-case when there are no matching words

### DIFF
--- a/christmais/parser.py
+++ b/christmais/parser.py
@@ -75,9 +75,9 @@ class Parser:
                 # small
                 cat = 'dog'
                 scores = np.random.uniform(0, 0.3)
-            else:
-                cat_list.append(cat)
-                score_list.append(scores)
+            # Append anyway
+            cat_list.append(cat)
+            score_list.append(scores)
         sim_label = cat_list[np.argmax(score_list)]
         sim_score = np.max(score_list)
         return self._get_actual_label(sim_label), sim_score


### PR DESCRIPTION
We just set the category into an arbitrary class, and set the score to something very low so that it will have little effect on the overall computation.
